### PR TITLE
Upgrade to VS2022

### DIFF
--- a/src/RustLanguageExtension.sln
+++ b/src/RustLanguageExtension.sln
@@ -1,9 +1,9 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28621.142
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32414.318
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RustLanguageExtension", "RustLanguageExtension\RustLanguageExtension.csproj", "{B4502D57-6DFE-4825-9D0B-B30D0E426502}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RustLanguageExtension", "RustLanguageExtension\RustLanguageExtension.csproj", "{B4502D57-6DFE-4825-9D0B-B30D0E426502}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/RustLanguageExtension/OptionsModel.cs
+++ b/src/RustLanguageExtension/OptionsModel.cs
@@ -6,7 +6,7 @@
 namespace RustLanguageExtension
 {
     using System;
-    using System.ComponentModel.Composition;
+    using System.Composition;
     using Microsoft.VisualStudio.Settings;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
@@ -27,8 +27,8 @@ namespace RustLanguageExtension
         private const string RustupPathDefault = "";
         private const string RustupPathProperty = "RustupPath";
 
-        private static string toolchain;
-        private static string rustupPath;
+        private static string toolchain = ToolchainDefault;
+        private static string rustupPath = RustupPathDefault;
 
         private readonly IServiceProvider syncServiceProvider;
 
@@ -37,7 +37,7 @@ namespace RustLanguageExtension
         /// </summary>
         /// <param name="syncServiceProvider">VS service provider.</param>
         [ImportingConstructor]
-        public OptionsModel([Import(typeof(SVsServiceProvider))] IServiceProvider syncServiceProvider)
+        public OptionsModel([Import("Microsoft.VisualStudio.Shell.SVsServiceProvider")] IServiceProvider syncServiceProvider)
         {
             this.syncServiceProvider = syncServiceProvider;
         }

--- a/src/RustLanguageExtension/RustLanguageExtension.csproj
+++ b/src/RustLanguageExtension/RustLanguageExtension.csproj
@@ -1,18 +1,14 @@
-﻿<Project>
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>17.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-  </PropertyGroup>
-
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
-
-  <PropertyGroup>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>TargetFramework</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyName>RustLanguageExtension</AssemblyName>
-    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+	<ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+	<IncludePkgdefInVSIXContainer>false</IncludePkgdefInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
@@ -21,25 +17,66 @@
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
     <UseCodebase>true</UseCodebase>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<LangVersion>8.0</LangVersion>
+	<Nullable>enable</Nullable>
+	<DebugType>portable</DebugType>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <CreateVsixContainer>True</CreateVsixContainer>
+    <DeployExtension>True</DeployExtension>
+    <CopyVsixExtensionFiles>True</CopyVsixExtensionFiles>
+	<!-- Enable the dummy target to force the VSIX build when using the .NET Standard. -->
+	<ForceVsixBuild>true</ForceVsixBuild>
+	<!-- Emulation of parts of Microsoft.CSharp.targets to enable Microsoft.VsSDK.targets: -->
+	<EmulateMicrosoftCSharpTargets>$(ForceVsixBuild)</EmulateMicrosoftCSharpTargets>
+  </PropertyGroup>
   <ItemGroup>
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
+    <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost" Version="17.1.386" />
+    <PackageReference Include="Microsoft.VisualStudio.CoreUtility" Version="17.1.386" />
+    <PackageReference Include="Microsoft.VisualStudio.ImageCatalog" Version="17.1.32210.191" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.1.68" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.1.32210.191" />
+    <PackageReference Include="Microsoft.VisualStudio.Settings.15.0" Version="17.1.32210.191" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.Framework" Version="17.1.32210.191" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.1.46" />
+    <PackageReference Include="Microsoft.VisualStudio.Utilities" Version="17.1.32210.191" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="16.3.43" />
+    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="16.3.43" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4057">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.3.310801">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Madskristensen.VisualStudio.SDK" Version="15.8.81-pre" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace" Version="15.0.485" />
-    <PackageReference Include="Microsoft.VisualStudio.Workspace.VSIntegration" Version="15.0.485" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.0.2258" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.255" />
+    <PackageReference Update="StyleCop.Analyzers" Version="1.1.118" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.ComponentModel.Composition" />
-  </ItemGroup>
-
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" />
+  <!-- Dummy target just to trigger the VSIX build. I am no MSBuild expert, but despite all the things added to PrepareForRunDependsOn, it still seems necessary. -->
+  <Target Name="ForceVsixBuild" AfterTargets="Build" Condition="$(ForceVsixBuild)"
+    DependsOnTargets="GeneratePkgDef;
+      CopyPkgDef;
+      CreateVsixContainer;
+      DeployVsixExtensionFiles;
+      CopyVsixManifestFile;
+      CopyVsixExtensionFiles;"/>
+  <!-- Emulation of parts of Microsoft.CSharp.targets to enable Microsoft.VsSDK.targets: -->
+  <PropertyGroup Condition="$(EmulateMicrosoftCSharpTargets)">
+    <TargetName Condition=" '$(TargetName)' == '' ">$(AssemblyName)</TargetName>
+    <TargetExt Condition="'$(TargetExt)' == '' and '$(OutputType)'=='library'">.dll</TargetExt>
+    <TargetFileName Condition=" '$(TargetFileName)' == '' ">$(TargetName)$(TargetExt)</TargetFileName>
+	<OutDir Condition=" '$(OutDir)' == '' ">$(OutputPath)</OutDir>
+    <OutDir Condition="'$(OutDir)' != '' and !HasTrailingSlash('$(OutDir)')">$(OutDir)\</OutDir>
+	<TargetDir Condition="'$(OutDir)' != ''">$([MSBuild]::Escape($([System.IO.Path]::GetFullPath(`$([System.IO.Path]::Combine(`$(MSBuildProjectDirectory)`, `$(OutDir)`))`))))</TargetDir>
+    <TargetPath Condition=" '$(TargetPath)' == '' ">$(TargetDir)$(TargetFileName)</TargetPath>
+	<BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">obj\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="!HasTrailingSlash('$(BaseIntermediateOutputPath)')">$(BaseIntermediateOutputPath)\</BaseIntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' == 'AnyCPU'">$(BaseIntermediateOutputPath)$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == '' and '$(PlatformName)' != 'AnyCPU'">$(BaseIntermediateOutputPath)$(PlatformName)\$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="!HasTrailingSlash('$(IntermediateOutputPath)')">$(IntermediateOutputPath)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/src/RustLanguageExtension/Rustup.cs
+++ b/src/RustLanguageExtension/Rustup.cs
@@ -143,7 +143,7 @@ namespace RustLanguageExtension
             return new CommandResult
             {
                 Output = output,
-                ExitCode = p.ExitCode
+                ExitCode = p.ExitCode,
             };
         }
 

--- a/src/RustLanguageExtension/VSPackage.resx
+++ b/src/RustLanguageExtension/VSPackage.resx
@@ -1,27 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!--
-    VS SDK Notes: This resx file contains the resources that will be consumed from your package by Visual Studio.
-    For example, Visual Studio will attempt to load resource '400' from this resource stream when it needs to
-    load your package's icon. Because Visual Studio will always look in the VSPackage.resources stream first for
-    resources it needs, you should put additional resources that Visual Studio will load directly into this resx
-    file.
-
-    Resources that you would like to access directly from your package in a strong-typed fashion should be stored
-    in Resources.resx or another resx file.
--->
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -36,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -127,11 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="110" xml:space="preserve">
-    <value>RustLanguageExtensionOptionsPackage Extension</value>
+    <value>Rust Language Extension</value>
   </data>
   <data name="112" xml:space="preserve">
-    <value>RustLanguageExtensionOptionsPackage Visual Studio Extension Detailed Info</value>
+    <value>Rust support for Visual Studio</value>
   </data>
 </root>

--- a/src/RustLanguageExtension/VsUtilities.cs
+++ b/src/RustLanguageExtension/VsUtilities.cs
@@ -29,7 +29,7 @@ namespace RustLanguageExtension
         public delegate void InfoBarEventHandler(object source, InfoBarEventArgs e);
 
         /// <summary>
-        /// Create a task in the VS task status center
+        /// Create a task in the VS task status center.
         /// </summary>
         /// <param name="title">The name of the task.</param>
         /// <param name="serviceProvider">VS async service provider.</param>

--- a/src/RustLanguageExtension/source.extension.vsixmanifest
+++ b/src/RustLanguageExtension/source.extension.vsixmanifest
@@ -3,21 +3,22 @@
     <Metadata>
         <Identity Id="RustLanguageExtension.5c010d5e-68dd-4c38-a7ca-c2ac3a8103fd" Version="|%CurrentProject%;GetBuildVersion|" Language="en-US" Publisher="Daniel Griffen" />
         <DisplayName>Rust</DisplayName>
-        <Description xml:space="preserve">Rust Extension for VS2017 with Language Server Support</Description>
-        <ReleaseNotes>https://github.com/dgriffen/rls-vs2017/blob/master/CHANGELOG.md</ReleaseNotes>
+        <Description xml:space="preserve">Rust Extension for VS2022 with Language Server Support</Description>
+        <ReleaseNotes>https://github.com/inequation/rls-vs2022/blob/master/CHANGELOG.md</ReleaseNotes>
         <Icon>rust-logo-256x256.png</Icon>
     </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[15.0.27825.0, 17.0)" />
+	<Installation>
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <ProductArchitecture>amd64</ProductArchitecture>
+      </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Assets>
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+		<Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0, 18.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Addressing #29. There's work left to be done if the extension is to work with both 2022+ and 2019-, as there have been breaking VS extension API changes (thanks Microsoft!), so this likely can't be taken as-is, but at least it brings working syntax highlighting and completion into VS2022, and frankly, at this point my interest in spending more time on it wanes.

Work done:
- upgrading the .NET framework from 4.x to .NET Standard 2.0 with `upgrade-assistant`
- upgrading all the SDK NuGet packages
- upgrading C# language version to 8.0 (as required by some of the APIs that now have optional generics)
- hacking the `.csproj` to actually call the MSBuild tasks to build the VSIX file

A bunch of warnings remain, and the options page does not seem to work (there's a warning about CPU arch of the dependent packages that's likely relevant), but we have syntax highlighting and completion working.